### PR TITLE
add an expiration rule for non_current version of codebuild caches

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -274,6 +274,10 @@ resource "aws_s3_bucket" "codebuild_cache" {
       days = "7"
     }
 
+    noncurrent_version_expiration {
+      days = "1"
+    }
+
     abort_incomplete_multipart_upload_days = "1"
   }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***
Codebuild cache will be increasing in size, and codebuild won't download previous versions of the cache, thus the objects are not valuable.
***

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
