### PR TITLE
[WIP] enable empty appbin_writers

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -456,7 +456,7 @@ data "aws_iam_policy_document" "appbin_bucket_policy" {
       type = "AWS"
 
       identifiers = [
-        "${length(var.appbin_writers) > 0 ? "":module.codepipeline_role.role_arn}",
+        "${length(var.appbin_writers) > 0 ? "" : module.codepipeline_role.role_arn}",
         "${var.appbin_writers}",
       ]
     }

--- a/data.tf
+++ b/data.tf
@@ -450,13 +450,12 @@ data "aws_iam_policy_document" "codepipeline_s3" {
 data "aws_iam_policy_document" "appbin_bucket_policy" {
   statement {
     sid    = "AppbinWrite"
-    effect = "${length(var.appbin_writers) > 0 ? "Allow" : "Deny"}"
+    effect = "Allow"
 
     principals = {
       type = "AWS"
 
       identifiers = [
-        "${length(var.appbin_writers) > 0 ? "" : module.codepipeline_role.role_arn}",
         "${var.appbin_writers}",
       ]
     }

--- a/data.tf
+++ b/data.tf
@@ -28,57 +28,6 @@ data "aws_subnet" "selected" {
   id = "${random_shuffle.subnet_id.result[0]}"
 }
 
-## Will be required if the codebuild is in the VPC
-# data "aws_iam_policy_document" "codebuild_ec2" {
-#   statement {
-#     effect = "Allow"
-#
-#     actions = [
-#       "ec2:CreateNetworkInterface",
-#       "ec2:DescribeDhcpOptions",
-#       "ec2:DescribeNetworkInterfaces",
-#       "ec2:DeleteNetworkInterface",
-#       "ec2:DescribeSubnets",
-#       "ec2:DescribeSecurityGroups",
-#       "ec2:DescribeVpcs",
-#     ]
-#
-#     resources = [
-#       "*",
-#     ]
-#   }
-#
-#   statement {
-#     effect = "Allow"
-#
-#     actions = [
-#       "ec2:CreateNetworkInterfacePermission",
-#     ]
-#
-#     resources = [
-#       "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*",
-#     ]
-#
-#     condition = {
-#       test     = "StringEquals"
-#       variable = "ec2:AuthorizedService"
-#
-#       values = [
-#         "codebuild.amazonaws.com",
-#       ]
-#     }
-#
-#     condition = {
-#       test     = "StringEquals"
-#       variable = "ec2:Subnet"
-#
-#       values = [
-#         "${data.aws_subnet.selected.arn}",
-#       ]
-#     }
-#   }
-# }
-
 data "aws_iam_policy_document" "codebuild_s3" {
   statement {
     effect = "Allow"
@@ -501,13 +450,13 @@ data "aws_iam_policy_document" "codepipeline_s3" {
 data "aws_iam_policy_document" "appbin_bucket_policy" {
   statement {
     sid    = "AppbinWrite"
-    effect = "Allow"
+    effect = "${length(var.appbin_writers) > 0 ? "Allow" : "Deny"}"
 
     principals = {
       type = "AWS"
 
       identifiers = [
-        "${var.appbin_writers}",
+        "${length(var.appbin_writers) > 0 ? var.appbin_writers:module.codepipeline_role.role_arn}",
       ]
     }
 

--- a/data.tf
+++ b/data.tf
@@ -456,7 +456,8 @@ data "aws_iam_policy_document" "appbin_bucket_policy" {
       type = "AWS"
 
       identifiers = [
-        "${length(var.appbin_writers) > 0 ? var.appbin_writers:module.codepipeline_role.role_arn}",
+        "${length(var.appbin_writers) > 0 ? "":module.codepipeline_role.role_arn}",
+        "${var.appbin_writers}",
       ]
     }
 

--- a/main.tf
+++ b/main.tf
@@ -187,7 +187,7 @@ resource "aws_s3_bucket" "application_binary" {
     }
   }
 
-  policy = "${data.aws_iam_policy_document.appbin_bucket_policy.json}"
+  policy = "${length(var.appbin_writers) == 0 ? "" : data.aws_iam_policy_document.appbin_bucket_policy.json}"
 
   versioning {
     enabled = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,7 @@ variable "lambda_function_arn" {
 variable "appbin_writers" {
   description = "The IAM ARNs from other AWS Accounts that should be given access to write to the application binary bucket"
   type        = "list"
+  default     = []
 }
 
 variable "appbin_expiration_days" {


### PR DESCRIPTION
Inspired from https://stackoverflow.com/questions/55221614/aws-s3-bucket-policy-with-empty-principle-array
tested internally, applying this module with empty appbin_writers will result in
```
        {
            "Sid": "AppbinWrite",
            "Effect": "Deny",
            "Principal": {
                "AWS": "arn:aws:iam::<AWS_ACCOUNT_ID>:<CodePipeline_role>"
            },
            "Action": "s3:PutObject",
            "Resource": "<S3_ARN>",
            "Condition": {
                "StringEquals": {
                    "s3:x-amz-acl": "bucket-owner-full-control"
                }
            }
        },
```

EDIT: it's breaking non-empty appbin_writers though
```
 {
      "Sid": "AppbinWrite",
      "Effect": "Allow",
      "Principal": {
        "AWS": [
          "<appbin_writers>",
          "" // this line breaks this thing
        ]
      },
      "Condition": {
        "StringEquals": {
          "s3:x-amz-acl": "bucket-owner-full-control"
        }
      }
    },
```