### PR TITLE
permission required for ansible to copy artifact from ent-appbin

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -98,6 +98,7 @@ data "aws_iam_policy_document" "codebuild_s3" {
 
     actions = [
       "s3:GetObject",
+      "s3:ListBucket",
     ]
 
     resources = [


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-bake-ami-shared-resources/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

ami-baking codebuild is not able to pull artifact from <redacted s3 bucket> using ansible 

ERROR:

amazon-ebs: TASK [s3-deploy-object : get archive url from s3] ****************************** 
    amazon-ebs: An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (403) when calling the HeadBucket operation: Forbidden 
    amazon-ebs: fatal: [default -> 127.0.0.1]: FAILED! => {"boto3_version": "1.9.220", "botocore_version": "1.12.220", "changed": false, "error": {"code": "403", "message": "Forbidden"}, "msg": "Failed while looking up bucket (during bucket_check) <redacted>: **An error occurred (403) when calling the HeadBucket operation: Forbidden**", "response_metadata": {"host_id": "V+YBmhvNss8Oa0CTUri/STefsmnDK+E7S30oVt9drJbumoevCl9GkjJbn8EKxBe/fhGN9qHJYkI=", "http_headers": {"content-type": "application/xml", "date": "Wed, 20 Nov 2019 07:01:45 GMT", "server": "AmazonS3", "transfer-encoding": "chunked", "x-amz-bucket-region": "ap-southeast-1", "x-amz-id-2": "V+YBmhvNss8Oa0CTUri/STefsmnDK+E7S30oVt9drJbumoevCl9GkjJbn8EKxBe/fhGN9qHJYkI=", "x-amz-request-id": "F00E6CAF6842D478"}, "http_status_code": 403, "request_id": "F00E6CAF6842D478", "retry_attempts": 0}} 

Reason:
Codebuild not allowed for "S3:ListBucket" which allows **HEAD Bucket** operation

Source:
https://intellipaat.com/community/2808/aws-cli-s3-a-client-error-403-occurred-when-calling-the-headobject-operation-forbidden
https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html

Other steps taken to resolve error:
Tried adding region to ansible playbook as suggested in link above but it did't help
https://github.com/traveloka/ansible-s3-deploy-object/pull/2/files



```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
