### PR TITLE
allow codebuild to access ecr readonly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,9 +29,8 @@ resource "aws_iam_role_policy" "codebuild_policy_s3" {
   policy = "${data.aws_iam_policy_document.codebuild_s3.json}"
 }
 
-resource "aws_iam_policy_attachment" "test-attach" {
-  name       = "AmazonEC2ContainerRegistryReadOnly"
-  roles      = ["${module.codebuild_role.role_name}"]
+resource "aws_iam_role_policy_attachment" "codebuild_ecr" {
+  role      = "${module.codebuild_role.role_name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,12 @@ resource "aws_iam_role_policy" "codebuild_policy_s3" {
   policy = "${data.aws_iam_policy_document.codebuild_s3.json}"
 }
 
+resource "aws_iam_policy_attachment" "test-attach" {
+  name       = "AmazonEC2ContainerRegistryReadOnly"
+  roles      = ["${module.codebuild_role.role_name}"]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
 module "codepipeline_role" {
   source = "github.com/traveloka/terraform-aws-iam-role.git//modules/service?ref=v1.0.2"
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-bake-ami-shared-resources/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:
* Will attach AmazonEC2ContainerRegistryReadOnly policy to codebuild role for ami baking.

ENHANCEMENTS:
* feature: Add codebuild support for ecr image pull from .

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
  + module.shared_resources.aws_iam_role_policy_attachment.codebuild_ecr
      id:         <computed>
      policy_arn: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      role:       "ServiceRoleForCodebuild_srs-bake-ami-cab31da02868716d"

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
